### PR TITLE
refactor: only run spooker if run is not a stub run nor preview

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -36,10 +36,12 @@ include { PPQT_PROCESS
 include { NORMALIZE_INPUT          } from "./modules/local/deeptools.nf"
 
 workflow.onComplete {
-    println "Running spooker"
-    def message = Utils.spooker(workflow)
-    if (message) {
-        println message
+    if (!workflow.stubRun && !workflow.commandLine.contains('-preview')) {
+        println "Running spooker"
+        def message = Utils.spooker(workflow)
+        if (message) {
+            println message
+        }
     }
 }
 


### PR DESCRIPTION

## Changes

Check whether the nextflow CLI call was a stub run or preview -- if either, don't run spooker on completion.

## Issues

resolves #128

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
