### PR TITLE
fix: sort deeptools plots by file basenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Per sample fingerprint plots instead of per replicate
   - Input normalized profile plots
   - Protein-coding-only versions of plots
+  - Ensure sample IDs are sorted (#150)
 
 ## CHAMPAGNE 0.2.1
 

--- a/modules/local/deeptools.nf
+++ b/modules/local/deeptools.nf
@@ -81,9 +81,10 @@ process BIGWIG_SUM {
         path("bigWigSum.npz"), emit: array
 
     script:
+    // sort files on basenames, otherwise uses full file path
     """
     multiBigwigSummary bins \\
-      -b ${bigwigs.join(' ')} \\
+      -b ${bigwigs.sort({ a, b -> a.baseName <=> b.baseName }).join(' ')} \\
       --smartLabels \\
       -o bigWigSum.npz
     """
@@ -257,7 +258,7 @@ process COMPUTE_MATRIX {
   """
   echo "$mattype" > file.txt
   computeMatrix ${cmd} \\
-    -S ${bigwigs.sort().join(' ')} \\
+    -S ${bigwigs.sort({ a, b -> a.baseName <=> b.baseName }).join(' ')} \\
     -R ${bed} \\
     -p ${task.cpus} \\
     -o ${meta.id}.${bed.baseName}.${mattype}.mat.gz \\

--- a/subworkflows/local/deeptools/main.nf
+++ b/subworkflows/local/deeptools/main.nf
@@ -23,8 +23,8 @@ workflow DEEPTOOLS {
             .set { bigwigs }
 
         bigwigs
-            .map{ meta, bigwig -> bigwig } // sort files on basenames, otherwise uses full file path
-            .toSortedList( { a, b -> a.baseName <=> b.baseName } ) | BIGWIG_SUM
+            .map{ meta, bigwig -> bigwig }
+            .collect() | BIGWIG_SUM
         bw_array = BIGWIG_SUM.out.array
         bw_array.combine(Channel.of('heatmap', 'scatterplot')) | PLOT_CORRELATION
         bw_array | PLOT_PCA
@@ -63,7 +63,7 @@ workflow DEEPTOOLS {
         ch_all_bigwigs = Channel.value([ id: 'inputnorm' ])
             .combine(bigwigs_norm)
             .mix(bigwigs_raw)
-            .groupTuple()
+            .groupTuple() // sort files on basenames, otherwise uses full file path
             .combine(beds)
             .combine(Channel.of('metagene','TSS'))
         COMPUTE_MATRIX(ch_all_bigwigs)


### PR DESCRIPTION
otherwise, it uses the full filepath which may contain the workdir random hash

## Changes

Ensure files in bigwig_sum and compute_matrix are sorted by the file basename, so sample IDs will be sorted in the ensuing plots.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
