### PR TITLE
fix: don't run chmod_bins_exec() in run function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           python -m pip install --upgrade pip setuptools
           mkdir -p tests/bin/
           pip install .[dev,test]
+          python -c 'from champagne.src.util import chmod_bins_exec; chmod_bins_exec()'
       - name: Stub run
         run: |
           cd tests/cli

--- a/src/util.py
+++ b/src/util.py
@@ -153,8 +153,6 @@ def run_nextflow(
 ):
     """Run a Nextflow workflow"""
     nextflow_command = ["nextflow", "run", nextfile_path]
-    # make sure bins are executable for nextflow processes
-    chmod_bins_exec()
 
     hpc = get_hpc()
     if mode == "slurm" and not hpc:


### PR DESCRIPTION
but do run it after installation in the github action


## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
