### PR TITLE
docs: use mike plugin for multiple versions on website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: mkdocs
+name: docs
 on:
   workflow_dispatch:
   push:
@@ -26,10 +26,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   actor: "41898282+github-actions[bot]"
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   deploy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,7 @@ jobs:
             groups = ['major', 'minor', 'patch']
             if current_semver.group('prerelease') and any([current_semver.group(grp) >= release_semver.group(grp) for grp in groups]):
               docs_alias = 'dev'
-              docs_version = current_semver
+              docs_version = current_version
             else:
               raise ValueError(f"current version {current_version} is not greater than latest release {release_tag}")
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
             current_semver = re.match(semver_pattern, current_version)
 
             groups = ['major', 'minor', 'patch']
-            if current_semver.group('prerelease') and any([current_semver.group(grp) > release_semver.group(grp) for grp in groups]):
+            if current_semver.group('prerelease') and any([current_semver.group(grp) >= release_semver.group(grp) for grp in groups]):
               docs_alias = 'dev'
               docs_version = current_semver
             else:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,14 @@ on:
       - "**.md"
       - .github/workflows/docs.yml
       - mkdocs.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "**.md"
+      - .github/workflows/docs.yml
+      - mkdocs.yml
 
 env:
   actor: "41898282+github-actions[bot]"
@@ -18,13 +26,60 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9
+          cache: pip
+      - run: pip install --upgrade pip -r docs/requirements.txt
       - name: git config
         run: |
           git config --local user.email "${actor}@users.noreply.github.com"
           git config --local user.name "$actor"
-      - run: pip install --upgrade pip
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+          gh release list > releases.tsv
+      - name: get version tag & alias
+        shell: python {0}
+        run: |
+          import os
+          import re
+          import warnings
+
+          release_tag = ''
+          with open('releases.tsv', 'r') as infile:
+            for line in infile:
+              release_name, latest, tag, timestamp = line.strip().split('\t')
+              if latest == "Latest":
+                release_tag = tag.strip('v')
+                break
+          if not release_tag:
+            warnings.warn("No latest release found")
+
+          with open('VERSION', 'r') as infile:
+            current_version = infile.read().strip()
+
+          if current_version == release_tag:
+            docs_alias = 'latest'
+            docs_version = release_tag
+          else:
+            semver_pattern = '(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
+            release_semver = re.match(semver_pattern, release_tag)
+            current_semver = re.match(semver_pattern, current_version)
+
+            groups = ['major', 'minor', 'patch']
+            if current_semver.group('prerelease') and any([current_semver.group(grp) > release_semver.group(grp) for grp in groups]):
+              docs_alias = 'dev'
+              docs_version = current_semver
+            else:
+              raise ValueError(f"current version {curren_version} is not greater than latest release {release_tag}")
+
+          with open(os.getenv("GITHUB_ENV"), 'a') as out_env:
+            out_env.write(f"VERSION={docs_version}\n")
+            out_env.write(f"ALIAS={docs_alias}\n")
+
+      - name: deploy docs
+        run: |
+          mike deploy ${{ env.VERSION }} ${{ env.ALIAS }} \
+            --push \
+            --update-aliases \
+            --branch gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
               docs_alias = 'dev'
               docs_version = current_semver
             else:
-              raise ValueError(f"current version {curren_version} is not greater than latest release {release_tag}")
+              raise ValueError(f"current version {current_version} is not greater than latest release {release_tag}")
 
           with open(os.getenv("GITHUB_ENV"), 'a') as out_env:
             out_env.write(f"VERSION={docs_version}\n")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Implement differential peak calling. (#158)
   - Optionally specify contrasts via a YAML file. If no file is specified, differential analysis is not performed.
   - If any sample has only one replicate, run `MAnorm`, otherwise run `diffbind`.
+- The docs website now has a dropdown menu to select which version to view. The latest release is shown by default. (#170)
 
 ### Bug fixes
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,5 @@ mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-material==9.1.6
 #https://pypi.org/project/mkdocs-material-extensions/
 mkdocs-material-extensions==1.1.1
+#https://github.com/jimporter/mike
+mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,10 @@ plugins:
   - git-revision-date
   - minify:
       minify_html: true
+  - mike:
+      alias_type: symlink
+      canonical_version: latest
+      version_selector: true
 
 # Customization
 extra:


### PR DESCRIPTION
## Changes

This will help users find the correct version of the documentation.
The website will point to the latest release instead of the dev version by default, and you can select the version to view from a dropdown menu.

- Configure the mike plugin for mkdocs
- Add steps to the docs action to determine the version and alias of the docs build.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
