### PR TITLE
fix: check whether contrastsheet param is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 ## CHAMPAGNE development version
 
+### New features
+
 - Create a script (`bin/champagne`) to provide an interface to the champagne CLI that works out-of-the-box without the need to install the python package with `pip`. (#180, @kelly-sovacool)
   - However, any dependencies not in the Python Standard Library must be installed for this to work. See the dependencies list in `pyproject.toml`.
+- Allow additional columns in the sample sheet beyond the minimum required header. (#176, @kelly-sovacool)
+- Add a workflow entry point to download fastq files from SRA. (#176, @kelly-sovacool)
+- Add `test_human` profile with chipseq data from ENCODE. (#176, @kelly-sovacool)
+
+### Bug fixes
+
 - Fix configuration files for compatibility with using the GitHub repo as the source. (#173, @kelly-sovacool)
   - These equivalent commands now work:
     ```sh
@@ -9,11 +17,14 @@
     champagne run --main CCBR/CHAMPAGNE
     ```
 - Allow multiple samples to use the same input. (#176, @kelly-sovacool)
-- Allow additional columns in the sample sheet beyond the minimum required header. (#176, @kelly-sovacool)
+- In the biowulf config profile, switch variable $SLURM_JOBID to $SLURM_JOB_ID. (@kelly-sovacool)
+- Increase resource allocations for chipseeker and deeptools. (#192, @slsevilla)
+- Check the validity of the contrastsheet earlier on in the workflow. (#192, @slsevilla; #200, @kelly-sovacool)
+
+### Misc
+
 - Change the peak widths histogram type from overlay to stack. (#176, @kelly-sovacool)
-- Add a workflow entry point to download fastq files from SRA. (#176, @kelly-sovacool)
-- Add `test_human` profile with chipseq data from ENCODE. (#176, @kelly-sovacool)
-- In biowulf config profile, switch variable $SLURM_JOBID to $SLURM_JOB_ID. (@kelly-sovacool)
+- Documentation improvements. (#192, @slsevilla)
 
 ## CHAMPAGNE 0.3.0
 

--- a/conf/full_mm10.config
+++ b/conf/full_mm10.config
@@ -5,7 +5,6 @@ params {
     genome = 'mm10'
     outdir = "results/full_mm10"
     input = "${projectDir}/assets/samplesheet_full_mm10.csv"
-    contrasts = 'true'
     contrastsheet = "${projectDir}/assets/contrasts_full_mm10.yml"
     sicer {
         species = "mm10" // supported species https://github.com/zanglab/SICER2/blob/master/sicer/lib/GenomeData.py

--- a/conf/test_human.config
+++ b/conf/test_human.config
@@ -5,7 +5,7 @@ params {
     genome = 'hg38'
     outdir = "results/human"
     input = "assets/samplesheet_human.csv"
-    contrasts = false //'assets/contrasts_human.yml'
+    contrastsheet = null //'assets/contrasts_human.yml'
     //read_length = 50
     sicer.species = "${params.genome}" // supported species https://github.com/zanglab/SICER2/blob/master/sicer/lib/GenomeData.py
 

--- a/conf/test_mm10.config
+++ b/conf/test_mm10.config
@@ -5,7 +5,6 @@ params {
     genome = 'mm10'
     outdir = "results/test_mm10"
     input = "${projectDir}/assets/samplesheet_test_mm10.csv"
-    contrasts = 'true'
     contrastsheet = "${projectDir}/assets/contrasts_test_mm10.yml"
     read_length = 50
     sicer.species = "mm10" // supported species https://github.com/zanglab/SICER2/blob/master/sicer/lib/GenomeData.py

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,7 +2,6 @@ nextflow.enable.dsl = 2
 
 params {
     input = null
-    contrasts = false
     seq_center = null
     read_length = null
     genome = null

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -20,8 +20,8 @@ workflow INPUT_CHECK {
             .set { reads }
 
         // Run check on the contrast manifest
-        contrasts=Channel.empty()
-        if (params.contrasts) {
+        ch_contrasts = Channel.empty()
+        if (contrastsheet) {
             CHECK_CONTRASTS(valid_csv, contrastsheet)
                 .csv
                 .flatten()
@@ -31,13 +31,13 @@ workflow INPUT_CHECK {
                     [ sample_basename: meta.sample_basename, group: meta.group, contrast: meta.contrast ]
                 }
                 .unique()
-                .set{ contrasts }
+                .set{ ch_contrasts }
         }
 
     emit:
         reads                               = reads      // channel: [ val(meta), [ reads ] ]
         csv                                 = valid_csv
-        contrasts                           = contrasts
+        contrasts                           = ch_contrasts
         versions                            = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }
 


### PR DESCRIPTION
## Changes

Remove redundant `contrasts` param, instead just set `contrastsheet` to null by default and check whether it is null before trying to create the file/path channel.

## Issues

- resolves #196
- partly undoes some of the changes from #192, which was merged prematurely

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
