### PR TITLE
feat: add manifest.version entry & read from VERSION file

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,5 @@
 log.info """\
-         CHAMPAGNE 🍾
+         CHAMPAGNE $workflow.manifest.version 🍾
          =============
          NF version   : $nextflow.version
          runName      : $workflow.runName
@@ -46,6 +46,10 @@ workflow.onComplete {
             println message
         }
     }
+}
+
+workflow version {
+    println "CHAMPAGNE ${workflow.manifest.version}"
 }
 
 workflow DOWNLOAD_SRA {

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,6 +163,8 @@ report {
 
 includeConfig 'conf/modules.config'
 
+String pipeline_version = new File("${projectDir}/VERSION").text
+
 manifest {
     name = "CCBR/CHAMPAGNE"
     author = "CCR Collaborative Bioinformatics Resource"
@@ -170,6 +172,7 @@ manifest {
     description = "CHromAtin iMmuno PrecipitAtion sequencinG aNalysis pipEline"
     mainScript = "main.nf"
     defaultBranch = "main"
+    version = "${pipeline_version}"
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
## Changes

nf-core tools now requires pipelines to have a version entry in the manifest section of `nextflow.config`. We use a single-source version file for the python package. This adds groovy code to the `nextflow.config` to read the version from the version file.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
