### PR TITLE
feat: --output argument for run & init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Use `nextflow run -resume` by default, or turn it off with `champagne run --forceall`. (#224, @kelly-sovacool)
 - New consensus peak method from Corces _et al._ ([doi:10.1126/science.aav1898](https://www.science.org/doi/10.1126/science.aav1898)). (#225, @kelly-sovacool)
 - Enable the nextflow timeline & trace reports by default. (#226, @kelly-sovacool)
-- Add `--output` argument for `champagne init` and `champagne run`.
+- Add `--output` argument for `champagne init` and `champagne run`. (#232, @kelly-sovacool)
   - This is equivalent to the nextflow launchDir constant.
 
 ## CHAMPAGNE 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Use `nextflow run -resume` by default, or turn it off with `champagne run --forceall`. (#224, @kelly-sovacool)
 - New consensus peak method from Corces _et al._ ([doi:10.1126/science.aav1898](https://www.science.org/doi/10.1126/science.aav1898)). (#225, @kelly-sovacool)
 - Enable the nextflow timeline & trace reports by default. (#226, @kelly-sovacool)
-
+- Add `--output` argument for `champagne init` and `champagne run`.
+  - This is equivalent to the nextflow launchDir constant.
 
 ## CHAMPAGNE 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ module load ccbrpipeliner
 Initialize and run champagne with test data:
 
 ```sh
-# copy the champagne config files to your current directory
-champagne init
+# copy the champagne config files to your project directory.
+# --output is optional and defaults to your current working directory.
+champagne init --output /data/$USER/champagne_project
 # preview the champagne jobs that will run with the test dataset
-champagne run --mode local -profile test -preview
+champagne run --output /data/$USER/champagne_project --mode local -profile test -preview
 # launch a champagne run on slurm with the test dataset
-champagne run --mode slurm -profile test,biowulf
+champagne run --output /data/$USER/champagne_project --mode slurm -profile test,biowulf
 ```
 
 To run champagne on your own data, you'll need to create a sample sheet.
@@ -53,7 +54,7 @@ Once you've created a samplesheet with paths to your fastq files,
 run champagne with the `--input` option to specify the path to your sample sheet:
 
 ```sh
-champagne run --mode slurm -profile biowulf --input samplesheet.csv --genome hg38
+champagne run --output /data/$USER/champagne_project --mode slurm -profile biowulf --input samplesheet.csv --genome hg38
 ```
 
 We currently support the hg38 and mm10 genomes.
@@ -66,7 +67,8 @@ If you'd like to use a custom genome, you'll need the following files:
 Prepare your custom reference genome with:
 
 ```sh
-champagne run --mode slurm -profile biowulf \
+champagne run --output /data/$USER/champagne_project \
+    --mode slurm -profile biowulf \
     -entry MAKE_REFERENCE \
     --outdir custom_genome \
     --genome custom_genome \
@@ -80,7 +82,8 @@ The reference files and a config file for the genome will be written in `custom_
 Then you can run champagne using your custom genome:
 
 ```sh
-champagne run --mode slurm -profile biowulf \
+champagne run --output /data/$USER/champagne_project \
+    --mode slurm -profile biowulf \
     --input samplesheet.csv \
     --genome custom_genome \
     -c custom_genome/genome/custom_genome.config

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,13 @@ TODO
 
 ## Initialize
 
-Copy the configuration files to your current working directory
+Copy the configuration files to your project directory
+
+```sh
+champagne init --output /data/$USER/champagne_project
+```
+
+or if you do not use `--output`, your current working directory will be used as default:
 
 ```sh
 champagne init
@@ -30,25 +36,25 @@ TODO required params
 Run preview to view processes that will run:
 
 ```sh
-champagne run -profile test -preview
+champagne run --output /data/$USER/champagne_project -profile test -preview
 ```
 
 Launch a stub run to view processes that will run and download containers:
 
 ```sh
-champagne run -profile test,singularity -stub
+champagne run --output /data/$USER/champagne_project -profile test,singularity -stub
 ```
 
 Run the test dataset using the test profile:
 
 ```sh
-champagne run -profile test,singularity
+champagne run --output /data/$USER/champagne_project -profile test,singularity
 ```
 
-or explicitly specify the output directory and input:
+or explicitly specify the nextflow output directory and input:
 
 ```sh
-champagne run -profile singularity --outdir results/test --input assets/samplesheet_test.csv
+champagne run --output /data/$USER/champagne_project -profile singularity --outdir results/test --input assets/samplesheet_test.csv
 ```
 
 ### Custom reference genome
@@ -58,6 +64,6 @@ TODO different required params
 Create and use a custom reference genome:
 
 ```sh
-champagne run -profile test -entry MAKE_REFERENCE
-champagne run -profile test -c results/test/genome/custom_genome.config
+champagne run --output /data/$USER/champagne_project -profile test -entry MAKE_REFERENCE
+champagne run --output /data/$USER/champagne_project -profile test -c results/test/genome/custom_genome.config
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ requires-python = ">=3.8"
 dependencies = [
     "pyyaml >= 6.0",
     "Click >= 8.1.3",
-    "cffconvert >= 2.0.0"
+    "cffconvert >= 2.0.0",
+    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.2"
 ]
 
 [project.optional-dependencies]

--- a/src/util.py
+++ b/src/util.py
@@ -5,6 +5,7 @@ from time import localtime, strftime
 import click
 import collections.abc
 import os
+import pathlib
 import pprint
 import shutil
 import stat
@@ -54,16 +55,28 @@ def append_config_block(nf_config="nextflow.config", scope=None, **kwargs):
         f.write("}\n")
 
 
-def copy_config(config_paths, overwrite=True):
+def copy_config(config_paths, outdir: pathlib.Path, overwrite=True):
+    """
+    Copies default configuration files to the specified output directory.
+
+    Args:
+        config_paths (list): A list of paths to the local configuration files.
+        outdir (pathlib.Path): The output directory where the configuration files will be copied.
+        overwrite (bool, optional): Whether to overwrite existing files and directories. Defaults to True.
+
+    Raises:
+        FileNotFoundError: If a specified configuration file or directory does not exist.
+    """
     msg(f"Copying default config files to current working directory")
     for local_config in config_paths:
         system_config = nek_base(local_config)
+        output_config = outdir / local_config
         if os.path.isfile(system_config):
-            shutil.copyfile(system_config, local_config)
+            shutil.copyfile(system_config, output_config)
         elif os.path.isdir(system_config):
-            shutil.copytree(system_config, local_config, dirs_exist_ok=overwrite)
+            shutil.copytree(system_config, output_config, dirs_exist_ok=overwrite)
         else:
-            raise FileNotFoundError(f"Cannot copy {system_config} to {local_config}")
+            raise FileNotFoundError(f"Cannot copy {system_config} to {output_config}")
 
 
 def read_config(file):
@@ -153,6 +166,7 @@ def get_hpc():
 
 def run_nextflow(
     nextfile_path=None,
+    output_dir=pathlib.Path("."),
     mode="local",
     force_all=False,
     merge_config=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
 import json
 import os.path
+import pathlib
+import pytest
 import subprocess
 import tempfile
+from ccbr_tools.shell import shell_run
 
 # from champagne.src.util import run_nextflow
 
@@ -57,3 +60,23 @@ def test_forceall():
         if ":" in l
     }["cmd line"]
     assert "-preview" in cmd_line and "-resume" not in cmd_line
+
+
+def test_init():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output = shell_run(f"./bin/champagne init --output {tmp_dir}")
+        outdir = pathlib.Path(tmp_dir)
+        assertions = [(outdir / "nextflow.config").exists(), (outdir / "log").exists()]
+    assert all(assertions)
+
+
+def test_run_no_init():
+    with pytest.raises(Exception) as exc_info:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output = shell_run(
+                f"./bin/champagne run --output {tmp_dir}",
+                check=True,
+                capture_output=True,
+            )
+            assertions = ["Hint: you must initialize the output directory" in output]
+            assert all(assertions)


### PR DESCRIPTION
## Changes

Adds `--output` to `champagne run` and `champagne init`. Defaults to current working directory, but users are encouraged to specify it.

This is the same `--output` as in RENEE & XAVIER, which directly correspond to snakemake's `--directory` argument.
In this pipeline, `--output` effectively becomes the [nextflow launchDir](https://nextflow.io/docs/latest/config.html#constants).

Later, we should rename the `--workdir` argument of CARLISLE _et al._ to `--output` for consistency.

## Issues

- resolves #219
- resolves #217 - just look for `nextflow.config` in output dir
- implementation of https://github.com/CCBR/CCBR_NextflowTemplate/issues/40

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
