### PR TITLE
fix: correctly set Path.cwd() as default --output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           champagne init
           champagne run -profile docker -c ci_test.config
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() # run even if previous steps fail
         with:
           name: nextflow-log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Use `nextflow run -resume` by default, or turn it off with `champagne run --forceall`. (#224, @kelly-sovacool)
 - New consensus peak method from Corces _et al._ ([doi:10.1126/science.aav1898](https://www.science.org/doi/10.1126/science.aav1898)). (#225, @kelly-sovacool)
 - Enable the nextflow timeline & trace reports by default. (#226, @kelly-sovacool)
-- Add `--output` argument for `champagne init` and `champagne run`. (#232, @kelly-sovacool)
+- Add `--output` argument for `champagne init` and `champagne run`. (#232, #233, @kelly-sovacool)
   - This is equivalent to the nextflow launchDir constant.
 
 ## CHAMPAGNE 0.4.1

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -84,7 +84,8 @@ Run with a specific tag, branch, or commit from GitHub:
     "output_dir",
     help="Output path for champagne init & run. Equivalient to nextflow launchDir.",
     type=click.Path(file_okay=False, dir_okay=True, writable=True),
-    default=pathlib.Path("."),
+    default=pathlib.Path.cwd(),
+    show_default=True,
 )
 @click.option(
     "--mode",
@@ -142,7 +143,8 @@ def run(main_path, output_dir, _mode, force_all, **kwargs):
     "output_dir",
     help="Output path for champagne init & run. Equivalient to nextflow launchDir.",
     type=click.Path(file_okay=False, dir_okay=True, writable=True),
-    default=pathlib.Path("."),
+    default=pathlib.Path.cwd(),
+    show_default=True,
 )
 def init(output_dir, **kwargs):
     """Initialize the launch directory by copying the system default config files"""

--- a/src/util.py
+++ b/src/util.py
@@ -20,6 +20,7 @@ def nek_base(rel_path):
 
 
 def get_version():
+    msg_box(f"CWD {pathlib.Path.cwd()}")
     with open(nek_base("VERSION"), "r") as f:
         version = f.readline()
     return version

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,19 @@ def test_init():
     assert all(assertions)
 
 
+def test_init_default():
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.chdir(tmp_dir)
+        output = shell_run(f"{cwd}/bin/champagne init", check=False)
+        print(output)
+        outdir = pathlib.Path(tmp_dir)
+        assertions = [(outdir / "nextflow.config").exists(), (outdir / "log").exists()]
+
+    os.chdir(cwd)
+    assert all(assertions)
+
+
 def test_run_no_init():
     with pytest.raises(Exception) as exc_info:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,8 +74,7 @@ def test_init_default():
     cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as tmp_dir:
         os.chdir(tmp_dir)
-        output = shell_run(f"{cwd}/bin/champagne init", check=False)
-        print(output)
+        output = shell_run(f"{cwd}/bin/champagne init")
         outdir = pathlib.Path(tmp_dir)
         assertions = [(outdir / "nextflow.config").exists(), (outdir / "log").exists()]
 


### PR DESCRIPTION
## Changes

cannot use single-hyphen options e.g. -m, -o or else it may clash with nextflow's cli options. e.g. -profile clashed with -o (--output) and caused the command to be parsed as "-pr -o file"

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes. 
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
