### PR TITLE
docs: improve CLI help & set mode=slurm as default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
         run: |
           cd tests/nxf
           champagne init
-          champagne run -stub -c ci_stub.config --max_cpus 2 --max_memory 6.GB
+          champagne run -stub -c ci_stub.config --max_cpus 2 --max_memory 6.GB --mode local
       - name: Test run
         if: ${{ env.test_run == 'true' }}
         run: |
           cd tests/nxf
           champagne init
-          champagne run -profile docker -c ci_test.config
+          champagne run -profile docker -c ci_test.config --mode local
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v4
         if: always() # run even if previous steps fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,33 @@
 ## CHAMPAGNE development version
 
 - CHAMPAGNE now depends on ccbr_tools v0.4 for updated jobby & spooker utilities. (#247, @kelly-sovacool)
+
+### New features
+
 - Contrasts are now specified as a TSV file instead of YAML. (#224, @kelly-sovacool)
   - See the example contrast sheets in `assets/`.
-- Refactor checks for the sample sheet & contrast sheet to prevent unnecessary re-running. (#224, @kelly-sovacool)
-- Set `publish_dir_mode` to `link` by default.
-- Set `process.cache` to `deep` by default rather than lenient. (#224, @kelly-sovacool)
-- Fix a file name clash during input pooling. (#224, @kelly-sovacool)
-- Use `nextflow run -resume` by default, or turn it off with `champagne run --forceall`. (#224, @kelly-sovacool)
 - New consensus peak method from Corces _et al._ ([doi:10.1126/science.aav1898](https://www.science.org/doi/10.1126/science.aav1898)). (#225, #246, @kelly-sovacool)
-- Enable the nextflow timeline & trace reports by default. (#226, @kelly-sovacool)
-- Add `--output` argument for `champagne init` and `champagne run`. (#232, #233, @kelly-sovacool)
-  - This is equivalent to the nextflow launchDir constant.
+- CLI improvements
+  - Use `nextflow run -resume` by default, or turn it off with `champagne run --forceall`. (#224, @kelly-sovacool)
+  - Add `--output` argument for `champagne init` and `champagne run`. (#232, #233, @kelly-sovacool)
+    - This is equivalent to the nextflow launchDir constant.
+  - `--mode` now has `slurm` as the default. (#249, @kelly-sovacool)
+- Improved nextflow options:
+  - Set `publish_dir_mode` to `link` by default.
+  - Set `process.cache` to `deep` by default rather than lenient. (#224, @kelly-sovacool)
+  - Enable the nextflow timeline & trace reports by default. (#226, @kelly-sovacool)
+
+### Bug fixes
+
+- Refactor checks for the sample sheet & contrast sheet to prevent unnecessary re-running. (#224, @kelly-sovacool)
+- Fix a file name clash during input pooling. (#224, @kelly-sovacool)
 - Fix bug in MEME AME process that caused it not to run on all samples. (#234, @kelly-sovacool)
   - Also correct the motif rank calculation. (#234, @kopardev)
+
+### Documentation
+
 - Now using the readthedocs theme for the docs website. (#236, @kelly-sovacool)
+- Improved help message for `champagne run`. (#249, @kelly-sovacool)
 
 ## CHAMPAGNE 0.4.1
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -87,7 +87,7 @@ params {
         macs_broad = true
         macs_narrow = true
         normalize_peaks = false
-        chipseeker = true
+        chipseeker = false
         homer = true
         meme = true
         consensus_union = true

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -55,13 +55,20 @@ def cli():
 
 help_msg_extra = """
 \b
+Nextflow options:
+  -profile <profile>    Nextflow profile to use (e.g. test)
+  -params-file <file>   Nextflow params file to use (e.g. assets/params.yml)
+  -preview              Preview the processes that will run without executing them
+
+\b
 EXAMPLES:
 Execute with slurm:
-    champagne run ... --mode slurm
+  champagne run --output path/to/outdir --mode slurm
 Preview the processes that will run:
-    champagne run ... --mode local -preview
+  champagne run .--output path/to/outdir --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-    champagne run ... -work-dir path/to/workDir
+  champagne run --output path/to/outdir --mode slurm -profile test
+  champagne run --output path/to/outdir --mode slurm -profile test -params-file assets/params.yml
 """
 
 
@@ -94,7 +101,7 @@ Add nextflow args (anything supported by `nextflow run`):
     "_mode",
     help="Run mode (slurm, local)",
     type=str,
-    default="local",
+    default="slurm",
     show_default=True,
 )
 @click.option(
@@ -110,6 +117,9 @@ Add nextflow args (anything supported by `nextflow run`):
 def run(main_path, output, _mode, force_all, **kwargs):
     """
     Run the workflow
+
+    Note: you must first run `champagne init --output <output_dir>` to initialize
+    the output directory.
 
     docs: https://ccbr.github.io/CHAMPAGNE
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def test_citation():
 
 def test_preview():
     output = subprocess.run(
-        "./bin/champagne run -preview -c tests/nxf/ci_stub.config",
+        "./bin/champagne run -preview -c tests/nxf/ci_stub.config --mode local",
         capture_output=True,
         shell=True,
         text=True,
@@ -48,7 +48,7 @@ def test_preview():
 
 def test_forceall():
     output = subprocess.run(
-        "./bin/champagne run --forceall -preview -c tests/nxf/ci_stub.config",
+        "./bin/champagne run --forceall -preview -c tests/nxf/ci_stub.config --mode local",
         capture_output=True,
         shell=True,
         text=True,
@@ -86,7 +86,7 @@ def test_run_no_init():
     with pytest.raises(Exception) as exc_info:
         with tempfile.TemporaryDirectory() as tmp_dir:
             output = shell_run(
-                f"./bin/champagne run --output {tmp_dir}",
+                f"./bin/champagne run --output {tmp_dir} --mode local",
                 check=True,
                 capture_output=True,
             )


### PR DESCRIPTION
## Changes

- Improve CLI help message
- Set the default `--mode` to `slurm`

## Issues

see https://github.com/CCBR/CCBR_NextflowTemplate/issues/49

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
