### PR TITLE
fix: make sure pool inputs subworkflow is aware of paired-end reads

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -26,7 +26,7 @@ process {
         ]
     }
 
-    withName: '.*POOL_INPUTS:CONCAT_INPUTS' {
-        ext.prefix = { "${meta.id}.pooled"}
+    withName: '.*POOL_INPUTS:CONCAT_INPUTS.*' {
+        ext.prefix = { "${meta.id}.pooled.fastq.gz"}
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -165,7 +165,7 @@ workflow CHIPSEQ {
         // run differential analysis
         ch_contrasts = INPUT_CHECK.out.contrasts
         if (params.contrasts) {
-            // TODO use consensus peaks for regions of interest in diffbind
+            // TODO use consensus peaks for regions of interest in diffbind (merge peaks within contrast to create ROI)
             CALL_PEAKS.out.bam_peaks
                 .combine(deduped_bam)
                 .map{meta1, bam1, bai1, peak, tool, meta2, bam2, bai2 ->

--- a/subworkflows/local/pool_inputs/main.nf
+++ b/subworkflows/local/pool_inputs/main.nf
@@ -1,25 +1,62 @@
 
-include { CAT_CAT as CONCAT_INPUTS                  } from "../../../modules/nf-core/cat/cat"
+include { CAT_CAT as CONCAT_INPUTS_SINGLE;
+          CAT_CAT as CONCAT_INPUTS_PAIRED  } from "../../../modules/nf-core/cat/cat"
 
 workflow POOL_INPUTS {
     take:
         ch_reads
     main:
-        ch_reads.branch { meta, reads ->
-                input: meta.is_input
+        ch_reads
+            | branch { meta, reads ->
+                input_single: meta.is_input && meta.single_end
+                input_paired: meta.is_input && !meta.single_end
                 samples: !meta.is_input
             }
-            .set{ fastqs_branched }
+            | set{ fastqs_branched }
 
-        fastqs_branched.input.map { meta, reads ->
-            [ meta.sample_basename, meta, reads ]
+        // make sure forward and reverse reads are retained
+        fastqs_branched.input_paired
+            | map { meta, reads ->
+                [ [meta + [r: 1], meta + [r: 2]], [reads[0], reads[1]] ]
             }
-            .groupTuple()
-            .map{ sample_basename, metas, reads ->
-                [ [id: sample_basename, sample_basename: sample_basename, rep: '', single_end: metas[0].single_end, antibody: '', input: '', is_input: true], reads.flatten() ]}
-            | CONCAT_INPUTS
+            | transpose()
+            | map { meta, reads ->
+                [ "${meta.sample_basename}_R${meta.r}", meta, reads ]
+            }
+            | groupTuple()
+            | map{ group_name, metas, reads ->
+                def meta = metas[0]
+                meta.id = group_name
+                meta.rep = ''
+                meta.remove('r')
+                [ meta, reads.flatten().sort() ]
+            }
+            | CONCAT_INPUTS_PAIRED
+        CONCAT_INPUTS_PAIRED.out.file_out
+            | map { meta, read ->
+                [ meta.sample_basename, meta, read ]
+            }
+            | groupTuple()
+            | map { sample_basename, metas, reads ->
+                def meta = metas[0]
+                meta.id = sample_basename
+                [ meta, reads.flatten().sort() ]
+            }
 
-        CONCAT_INPUTS.out.file_out
+        fastqs_branched.input_single
+            | map { meta, reads ->
+                [ meta.sample_basename, meta, reads ]
+            }
+            | groupTuple()
+            | map{ sample_basename, metas, reads ->
+                def meta = metas[0]
+                meta.id = sample_basename
+                meta.rep = ''
+                [ meta, reads.flatten().sort() ]}
+            | CONCAT_INPUTS_SINGLE
+
+
+        CONCAT_INPUTS_SINGLE.out.file_out
             .mix(fastqs_branched.samples)
             .set{ mixed_reads }
 


### PR DESCRIPTION
## Changes

- concatenate R1 and R2 reads in separate files
- preserve file order with sort

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
