### PR TITLE
feat: re-do output directory structure with publishDir

### DIFF
--- a/assets/params.yml
+++ b/assets/params.yml
@@ -1,5 +1,4 @@
 input: './assets/samplesheet_test_mm10.csv'
-outdir: ./output/
 genome: mm10
 run:
   gem: false

--- a/conf/full_human.config
+++ b/conf/full_human.config
@@ -1,10 +1,10 @@
+outputDir = "${launchDir}/results/human"
 params {
     config_profile_name = 'Test human datasets'
     config_profile_description = 'Human datasets from ENCODE projects'
 
     genome = 'hg38'
-    outdir = "output/human"
-    input = "assets/samplesheet_full_human.csv"
+    input = "${projectDir}/assets/samplesheet_full_human.csv"
     contrasts = null
     //read_length = 50
     sicer.species = "${params.genome}" // supported species https://github.com/zanglab/SICER2/blob/master/sicer/lib/GenomeData.py

--- a/conf/full_mm10.config
+++ b/conf/full_mm10.config
@@ -1,9 +1,9 @@
+outputDir = "${launchdir}/results/full_mm10"
 params {
     config_profile_name = 'Full single-end mouse dataset'
     config_profile_description = 'Mouse dataset to benchmark pipeline function'
 
     genome = 'mm10'
-    outdir = "results/full_mm10"
     input = "${projectDir}/assets/samplesheet_full_mm10.csv"
     contrasts = "${projectDir}/assets/contrasts_full_mm10.tsv"
     sicer {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1,10 +1,10 @@
 process {
 
-    publishDir = [
-        path: { task.label ? "${params.outdir}/${task.label.findAll { !it.startsWith('process_') & !it.startsWith('error_') }.join('/')}/${task.process.tokenize(':')[-1].toLowerCase()}" : "${params.outdir}/${task.process.tokenize(':')[-1].toLowerCase()}" },
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
+    // publishDir = [
+    //     path: { task.label ? "${outputDir}/${task.label.findAll { !it.startsWith('process_') & !it.startsWith('error_') }.join('/')}/${task.process.tokenize(':')[-1].toLowerCase()}" : "${outputDir}/${task.process.tokenize(':')[-1].toLowerCase()}" },
+    //     mode: params.publish_dir_mode,
+    //     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+    // ]
 
     errorStrategy = 'finish'
 
@@ -12,7 +12,7 @@ process {
     withName: '.*CUSTOM_DUMPSOFTWAREVERSIONS' {
         cache = false
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
+            path: { "${outputDir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*_versions.yml'
         ]
@@ -20,13 +20,156 @@ process {
 
     withName: '.*INPUT_CHECK:CHECK_SAMPLESHEET' {
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
+            path: { "${outputDir}/pipeline_info" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
+    withName: '.*WRITE_GENOME_CONFIG' {
+        publishDir = [
+            path: { "${outputDir}/genome/"},
+            mode: params.publish_dir_mode,
+        ]
+    }
+
     withName: '.*POOL_INPUTS:CONCAT_INPUTS.*' {
         ext.prefix = { "${meta.id}.pooled.fastq.gz"}
+
+        publishDir = [
+            path: { "${outputDir}/fastq/inputs_pooled/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*CUTADAPT.*' {
+        publishDir = [
+            path: { "${outputDir}/fastq/trimmed/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*FASTQC_RAW.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/fastqc_raw/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*FASTQC_TRIMMED.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/fastqc_trimmed/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*PHANTOM_PEAKS.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/phantompeakqualtools/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*PRESEQ.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/preseq/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*DEEPTOOLS.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/deeptools/" },
+            mode: params.publish_dir_mode,
+    }
+    withName '.*QC_[STATS|TABLE].*' {
+        publishDir = [
+            path: { "${outputDir}/qc/stats/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*CHIPSEEKER.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/chipseeker/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*MULTIQC.*' {
+        publishDir = [
+            path: { "${outputDir}/qc/multiqc/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*DEDUPLICATE.*' {
+        publishDir = [
+            path: { "${outputDir}/align/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*MACS_BROAD.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/macs_broad/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*MACS_NARROW.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/macs_narrow/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*CONVERT_SICER.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/sicer/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*FILTER_GEM.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/gem/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*PLOT_FRIP.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/frip/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*PLOT_JACCARD.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/jaccard/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*PLOT_PEAK_WIDTHS.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/peak_widths/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*CONSENSUS_UNION.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/consensus_union/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*CONSENSUS_CORCES.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/consensus_corces/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*MOTIFS_.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/motifs/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*ANNOTATE_.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/annotate/" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName '.*DIFFBIND_RMD.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/diffbind/" },
+            mode: params.publish_dir_mode,
+        ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -29,7 +29,7 @@ process {
     withName: '.*WRITE_GENOME_CONFIG' {
         publishDir = [
             path: { "${outputDir}/genome/"},
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -38,138 +38,145 @@ process {
 
         publishDir = [
             path: { "${outputDir}/fastq/inputs_pooled/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*CUTADAPT.*' {
+    withName: '.*CUTADAPT.*' {
         publishDir = [
             path: { "${outputDir}/fastq/trimmed/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*FASTQC_RAW.*' {
+    withName: '.*FASTQC_RAW.*' {
         publishDir = [
             path: { "${outputDir}/qc/fastqc_raw/" },
             mode: params.publish_dir_mode,
         ]
     }
-    withName '.*FASTQC_TRIMMED.*' {
+    withName: '.*FASTQC_TRIMMED.*' {
         publishDir = [
             path: { "${outputDir}/qc/fastqc_trimmed/" },
             mode: params.publish_dir_mode,
         ]
     }
-    withName '.*PHANTOM_PEAKS.*' {
+    withName: '.*PHANTOM_PEAKS.*' {
         publishDir = [
             path: { "${outputDir}/qc/phantompeakqualtools/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*PRESEQ.*' {
+    withName: '.*PRESEQ.*' {
         publishDir = [
             path: { "${outputDir}/qc/preseq/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*DEEPTOOLS.*' {
+    withName: '.*DEEPTOOLS.*' {
         publishDir = [
             path: { "${outputDir}/qc/deeptools/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
+        ]
     }
-    withName '.*QC_[STATS|TABLE].*' {
+    withName: '.*QC_[STATS|TABLE].*' {
         publishDir = [
             path: { "${outputDir}/qc/stats/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*CHIPSEEKER.*' {
+    withName: '.*CHIPSEEKER.*' {
         publishDir = [
             path: { "${outputDir}/qc/chipseeker/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*MULTIQC.*' {
+    withName: '.*MULTIQC.*' {
         publishDir = [
             path: { "${outputDir}/qc/multiqc/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*DEDUPLICATE.*' {
+    withName: '.*DEDUPLICATE.*' {
         publishDir = [
             path: { "${outputDir}/align/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*MACS_BROAD.*' {
+    withName: '.*MACS_BROAD.*' {
         publishDir = [
             path: { "${outputDir}/peaks/macs_broad/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*MACS_NARROW.*' {
+    withName: '.*MACS_NARROW.*' {
         publishDir = [
             path: { "${outputDir}/peaks/macs_narrow/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*CONVERT_SICER.*' {
+    withName: '.*CONVERT_SICER.*' {
         publishDir = [
             path: { "${outputDir}/peaks/sicer/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*FILTER_GEM.*' {
+    withName: '.*FILTER_GEM.*' {
         publishDir = [
             path: { "${outputDir}/peaks/gem/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*PLOT_FRIP.*' {
+    withName: '.*PLOT_FRIP.*' {
         publishDir = [
             path: { "${outputDir}/peaks/frip/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*PLOT_JACCARD.*' {
+    withName: '.*PLOT_JACCARD.*' {
         publishDir = [
             path: { "${outputDir}/peaks/jaccard/" },
             mode: params.publish_dir_mode,
         ]
     }
-    withName '.*PLOT_PEAK_WIDTHS.*' {
+    withName: '.*PLOT_PEAK_WIDTHS.*' {
         publishDir = [
             path: { "${outputDir}/peaks/peak_widths/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*CONSENSUS_UNION.*' {
+    withName: '.*CONSENSUS_UNION.*' {
         publishDir = [
             path: { "${outputDir}/peaks/consensus_union/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*CONSENSUS_CORCES.*' {
+    withName: '.*CONSENSUS_CORCES.*' {
         publishDir = [
             path: { "${outputDir}/peaks/consensus_corces/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*MOTIFS_.*' {
+    withName: '.*HOMER.*' {
         publishDir = [
-            path: { "${outputDir}/peaks/motifs/" },
-            mode: params.publish_dir_mode,
+            path: { "${outputDir}/peaks/motifs/homer" },
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*ANNOTATE_.*' {
+    withName: '.*MEME_.*' {
+        publishDir = [
+            path: { "${outputDir}/peaks/motifs/meme" },
+            mode: params.publish_dir_mode
+        ]
+    }
+    withName: '.*CHIPSEEKER.*' {
         publishDir = [
             path: { "${outputDir}/peaks/annotate/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
-    withName '.*DIFFBIND_RMD.*' {
+    withName: '.*DIFFBIND_RMD.*' {
         publishDir = [
             path: { "${outputDir}/peaks/diffbind/" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,8 +1,8 @@
+outputDir = "${launchDir}/results/test"
 params {
     config_profile_name = 'Test paired-end and single-end mixed'
     config_profile_description = 'Minimal test dataset to check paired & single end handling'
 
-    outdir = 'output/test'
     input = "${projectDir}/assets/samplesheet_test.csv" // adapted from 'https://raw.githubusercontent.com/nf-core/test-datasets/chipseq/samplesheet/v2.0/samplesheet_test.csv'
     //contrasts = "${projectDir}/assets/contrasts_test.tsv" // diffbind DESeq2 fails on this test data
 

--- a/conf/test_human.config
+++ b/conf/test_human.config
@@ -1,10 +1,10 @@
+outputDir = "${launchDir}/results/human"
 params {
     config_profile_name = 'Test human datasets'
     config_profile_description = 'Human datasets from ENCODE projects'
 
     genome = 'hg38'
-    outdir = "output/human"
-    input = "assets/samplesheet_test_human.csv"
+    input = "${projectDir}/assets/samplesheet_test_human.csv"
     contrasts = null
     //read_length = 50
     sicer.species = "${params.genome}" // supported species https://github.com/zanglab/SICER2/blob/master/sicer/lib/GenomeData.py

--- a/conf/test_mm10.config
+++ b/conf/test_mm10.config
@@ -1,9 +1,9 @@
+outputDir = "${launchDir}/results/test_mm10"
 params {
     config_profile_name = 'Test single-end mouse dataset'
     config_profile_description = 'Minimal mouse dataset to check pipeline function'
 
     genome = 'mm10'
-    outdir = "output/test_mm10"
     input = "${projectDir}/assets/samplesheet_test_mm10.csv"
     contrasts = "${projectDir}/assets/contrasts_test_mm10.tsv"
     read_length = 50

--- a/modules/local/consensus/corces/main.nf
+++ b/modules/local/consensus/corces/main.nf
@@ -12,6 +12,7 @@ process CONSENSUS_CORCES {
     script:
     def cat_peak_file = "${meta.id}.${meta.tool}.cat.bed"
     def outfile = "${meta.id}.${meta.tool}.consensus_corces.bed"
+    meta.consensus = 'corces'
     """
     #cat ${peaks.join(' ')} > ${cat_peak_file}
     #consensus_corces.py ${cat_peak_file} ${outfile} ${chrom_sizes}

--- a/modules/local/prepare_genome.nf
+++ b/modules/local/prepare_genome.nf
@@ -126,10 +126,6 @@ process WRITE_GENOME_CONFIG {
     label 'process_single'
     container "${params.containers.base}"
 
-    publishDir = [
-        path: { "${params.outdir}/genome" },
-        mode: "copy"
-    ]
     input:
         path(fasta)
         path(gtf)
@@ -180,7 +176,7 @@ process WRITE_GENOME_CONFIG {
     pprint.pprint(genome)
     with open('${genome_name}.config', 'w') as conf_file:
         head = ["params {\\n",
-                '\\tindex_dir = "${params.outdir}/genome/"\\n',
+                '\\tindex_dir = "\${outputDir}/genome/"\\n',
                 "\\tgenomes {\\n"
                 "\\t\\t'${genome_name}' {\\n"]
         conf_file.writelines(head)

--- a/modules/local/qc.nf
+++ b/modules/local/qc.nf
@@ -3,7 +3,6 @@ process FASTQC {
     tag { meta.id }
     label 'qc'
     label 'process_high'
-    publishDir "${params.outdir}/qc/fastqc_${fqtype}/${meta.id}", mode: "${params.publish_dir_mode}"
 
     container = "${params.containers.fastqc}"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,5 @@
-nextflow.enable.dsl = 2
+
+outputDir = "${launchDir}/results"
 
 params {
     input = null
@@ -17,8 +18,7 @@ params {
     rename_contigs = null
 
     // Boilerplate options
-    outdir = 'output'
-    tracedir = "${params.outdir}/pipeline_info"
+    tracedir = "${outputDir}/pipeline_info"
     publish_dir_mode = 'link'
 
     // Max resource options
@@ -81,7 +81,6 @@ params {
         qc = true
         deeptools = true
         normalize_input = true
-        call_peaks = true
         gem = true
         sicer = true
         macs_broad = true
@@ -94,6 +93,7 @@ params {
         consensus_corces = true
     }
 }
+
 
 includeConfig 'conf/base.config'
 
@@ -155,22 +155,28 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 def trace_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
+    file    = "${outputDir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${trace_timestamp}.html"
+    file    = "${outputDir}/pipeline_info/execution_report_${trace_timestamp}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+    file    = "${outputDir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${trace_timestamp}.png"
+    file    = "${outputDir}/pipeline_info/pipeline_dag_${trace_timestamp}.png"
 }
 
 includeConfig 'conf/modules.config'
+
+// workflow {
+//     output {
+//         mode = params.publish_dir_mode
+//     }
+// }
 
 String pipeline_version = new File("${projectDir}/VERSION").text
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -94,7 +94,6 @@ params {
     }
 }
 
-
 includeConfig 'conf/base.config'
 
 profiles {

--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -33,7 +33,10 @@ workflow CONSENSUS_PEAKS {
         SORT_BED( CAT_CAT.out.file_out )
         BEDTOOLS_MERGE(SORT_BED.out.bed, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
         CONSENSUS_UNION(BEDTOOLS_MERGE.out.bed)
-        consensus_peaks = CONSENSUS_UNION.out.bed
+        consensus_peaks = CONSENSUS_UNION.out.bed.map { meta, bed ->
+            meta.consensus = 'union'
+            [meta, bed]
+        }
 
         ch_versions = ch_versions.mix(
             CAT_CAT.out.versions,

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -1,5 +1,4 @@
-include { HOMER_MOTIFS        } from "../../modules/local/homer"
-include { MEME_AME            } from "../../modules/local/meme"
+
 include { CHIPSEEKER_ANNOTATE } from "../../modules/local/chipseeker/annotate"
 include { CHIPSEEKER_PLOTLIST } from "../../modules/local/chipseeker/plotlist"
 include { CHIPSEEKER_PEAKPLOT } from "../../modules/local/chipseeker/peakplot"
@@ -7,8 +6,6 @@ include { CHIPSEEKER_PEAKPLOT } from "../../modules/local/chipseeker/peakplot"
 workflow ANNOTATE {
     take:
         ch_peaks
-        genome_fasta
-        meme_motifs
         bioc_txdb
         bioc_annot
 
@@ -25,24 +22,7 @@ workflow ANNOTATE {
             )
 
         }
-        if (params.run.homer) {
-            HOMER_MOTIFS(ch_peaks.combine(genome_fasta).combine(Channel.fromPath(file(params.homer.jaspar_db, checkIfExists: true))),
-                         params.homer.de_novo,
-                        )
-            HOMER_MOTIFS.out.ame
-                | branch{ meta, background, target ->
-                    empty: background.isEmpty() | target.isEmpty()
-                    fasta: true
-                }
-                | set{ homer_ame }
-            homer_ame.empty
-                | subscribe{ meta, background, target ->
-                    println "Empty homer fasta for ${meta.id}"
-                }
-            if (params.run.meme && meme_motifs) {
-                MEME_AME(homer_ame.fasta.combine(meme_motifs))
-            }
-        }
+
 
     emit:
         plots = ch_plots

--- a/subworkflows/local/diffbind/main.nf
+++ b/subworkflows/local/diffbind/main.nf
@@ -8,7 +8,7 @@ workflow DIFFBIND {
         ch_bam_peaks_contrasts | PREP_DIFFBIND
 
         PREP_DIFFBIND.out.csv
-            .collectFile(storeDir: "${params.outdir}/diffbind/contrasts", newLine: false, keepHeader: true, skip: 1) { meta, row ->
+            .collectFile(storeDir: "${outputDir}/peaks/${meta.tool}/diffbind/contrasts", newLine: false, keepHeader: true, skip: 1) { meta, row ->
                 [ "${meta.contrast}.${meta.tool}.csv", row ]
             }
             .map{ contrast_file ->
@@ -20,6 +20,8 @@ workflow DIFFBIND {
 
                 meta = [:]
                 meta.id = "${params.contrast}.${params.tool}"
+                meta.contrast = params.contrast
+                meta.tool = params.tool
 
                 [ meta, params, contrast_file ]
             }

--- a/subworkflows/local/diffbind/main.nf
+++ b/subworkflows/local/diffbind/main.nf
@@ -8,17 +8,17 @@ workflow DIFFBIND {
         ch_bam_peaks_contrasts | PREP_DIFFBIND
 
         PREP_DIFFBIND.out.csv
-            .collectFile(storeDir: "${outputDir}/peaks/${meta.tool}/diffbind/contrasts", newLine: false, keepHeader: true, skip: 1) { meta, row ->
+            .collectFile(storeDir: "${outputDir}/peaks/diffbind/contrasts", newLine: false, keepHeader: true, skip: 1) { meta, row ->
                 [ "${meta.contrast}.${meta.tool}.csv", row ]
             }
             .map{ contrast_file ->
-                params = [:]
-                meta_list = contrast_file.baseName.tokenize('.')
+                def params = [:]
+                def meta_list = contrast_file.baseName.tokenize('.')
                 params.csvfile = contrast_file.getName()
                 params.contrast = meta_list[0]
                 params.tool = meta_list[1]
 
-                meta = [:]
+                def meta = [:]
                 meta.id = "${params.contrast}.${params.tool}"
                 meta.contrast = params.contrast
                 meta.tool = params.tool

--- a/subworkflows/local/differential/main.nf
+++ b/subworkflows/local/differential/main.nf
@@ -54,6 +54,6 @@ workflow DIFF {
 
     emit:
         diff_peaks = bam_peaks
-        // TODO
+        report = DIFFBIND.out.report
 
 }

--- a/subworkflows/local/motifs/main.nf
+++ b/subworkflows/local/motifs/main.nf
@@ -1,0 +1,32 @@
+include { HOMER_MOTIFS        } from "../../modules/local/homer"
+include { MEME_AME            } from "../../modules/local/meme"
+workflow MOTIFS {
+    take:
+        ch_peaks
+        genome_fasta
+        meme_motifs
+    main:
+        ch_plots = Channel.empty()
+        if (params.run.homer) {
+            HOMER_MOTIFS(ch_peaks.combine(genome_fasta).combine(Channel.fromPath(file(params.homer.jaspar_db, checkIfExists: true))),
+                         params.homer.de_novo,
+                        )
+            HOMER_MOTIFS.out.ame
+                | branch{ meta, background, target ->
+                    empty: background.isEmpty() | target.isEmpty()
+                    fasta: true
+                }
+                | set{ homer_ame }
+            homer_ame.empty
+                | subscribe{ meta, background, target ->
+                    println "Empty homer fasta for ${meta.id}"
+                }
+            if (params.run.meme && meme_motifs) {
+                MEME_AME(homer_ame.fasta.combine(meme_motifs))
+            }
+        }
+    emit:
+        plots = ch_plots
+        homer = HOMER_MOTIFS.out.motifs
+        meme = MEME_AME.out.ame.mix(MEME_AME.out.seq)
+}

--- a/subworkflows/local/motifs/main.nf
+++ b/subworkflows/local/motifs/main.nf
@@ -1,5 +1,5 @@
-include { HOMER_MOTIFS        } from "../../modules/local/homer"
-include { MEME_AME            } from "../../modules/local/meme"
+include { HOMER_MOTIFS        } from "../../../modules/local/homer"
+include { MEME_AME            } from "../../../modules/local/meme"
 workflow MOTIFS {
     take:
         ch_peaks

--- a/subworkflows/local/peaks.nf
+++ b/subworkflows/local/peaks.nf
@@ -84,7 +84,6 @@ workflow CALL_PEAKS {
         if (params.run.macs_narrow) {
             ch_macs | MACS_NARROW
             ch_peaks = ch_peaks.mix(MACS_NARROW.out.peak)
-            println 'adding macs peaks to ch_narrow_peaks'
             ch_narrow_peaks = ch_narrow_peaks.mix(MACS_NARROW.out.peak)
         }
         if (params.run.sicer) {
@@ -97,7 +96,6 @@ workflow CALL_PEAKS {
             GEM.out.peak
                 .combine(chrom_sizes) | FILTER_GEM
             ch_peaks = ch_peaks.mix(FILTER_GEM.out.peak)
-            println 'adding gem peaks to ch_narrow_peaks'
             ch_narrow_peaks = ch_narrow_peaks.mix(FILTER_GEM.out.peak)
         }
 

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -11,6 +11,7 @@ include { SPLIT_REF_CHROMS
 
 workflow PREPARE_GENOME {
     main:
+        ch_genome_conf = Channel.empty()
         if (params.genomes[ params.genome ]) {
             println "Using ${params.genome} as the reference"
 
@@ -95,9 +96,10 @@ workflow PREPARE_GENOME {
                 ch_gsize,
                 meme_motif_name,
                 ch_bioc_txdb,
-                ch_bioc_annot
+                ch_bioc_annot,
+
             )
-            println "Saving custom genome config in ${params.outdir}/genome"
+            ch_genome_conf = WRITE_GENOME_CONFIG.out.conf.mix(WRITE_GENOME_CONFIG.out.files)
 
         } else {
             error "Either specify a genome in `conf/genomes.conf`, or specify a genome fasta, gtf, and blacklist file to build a custom reference."
@@ -114,4 +116,5 @@ workflow PREPARE_GENOME {
         meme_motifs = ch_meme_motifs
         bioc_txdb = ch_bioc_txdb
         bioc_annot = ch_bioc_annot
+        conf = ch_genome_conf
 }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -13,8 +13,6 @@ workflow PREPARE_GENOME {
     main:
         ch_genome_conf = Channel.empty()
         if (params.genomes[ params.genome ]) {
-            println "Using ${params.genome} as the reference"
-
             ch_fasta = Channel.fromPath(params.genomes[ params.genome ].fasta, checkIfExists: true)
             ch_genes_gtf = Channel.fromPath(params.genomes[ params.genome ].genes_gtf, checkIfExists: true)
 
@@ -37,7 +35,6 @@ workflow PREPARE_GENOME {
             ch_bioc_annot = Channel.value(params.genomes[ params.genome ].bioc_annot)
 
         } else if (params.genome_fasta && params.genes_gtf && params.blacklist) {
-            println "Building a reference from provided genome fasta, gtf, and blacklist files"
             fasta_file = Channel.fromPath(params.genome_fasta, checkIfExists: true)
             gtf_file = file(params.genes_gtf, checkIfExists: true)
 

--- a/subworkflows/local/qc.nf
+++ b/subworkflows/local/qc.nf
@@ -83,14 +83,14 @@ workflow QC {
             QC_TABLE.out.txt,
             PRESEQ.out.c_curve
         )
-
+        ch_deeptools = Channel.empty()
         if (params.run.deeptools) {
             DEEPTOOLS( deduped_bam,
                        frag_lengths,
                        effective_genome_size,
                        gene_info
                      )
-            ch_multiqc = ch_multiqc.mix(
+            ch_deeptools = DEEPTOOLS.out.mix(
                 DEEPTOOLS.out.fingerprint_matrix,
                 DEEPTOOLS.out.fingerprint_metrics,
                 DEEPTOOLS.out.corr,
@@ -98,9 +98,13 @@ workflow QC {
                 DEEPTOOLS.out.profile,
                 DEEPTOOLS.out.heatmap
             )
+            ch_multiqc = ch_multiqc.mix(ch_deeptools)
         }
 
     emit:
         multiqc_input = ch_multiqc
+        fastqc_raw = FASTQC_RAW.out.zip.mix(FASTQC_RAW.out.html)
+        fastqc_trimmed = FASTQC_TRIMMED.out.zip.mix(FASTQC_TRIMMED.out.html)
+        deeptools = ch_deeptools
 
 }

--- a/subworkflows/local/qc.nf
+++ b/subworkflows/local/qc.nf
@@ -90,7 +90,7 @@ workflow QC {
                        effective_genome_size,
                        gene_info
                      )
-            ch_deeptools = DEEPTOOLS.out.mix(
+            ch_deeptools = ch_deeptools.mix(
                 DEEPTOOLS.out.fingerprint_matrix,
                 DEEPTOOLS.out.fingerprint_metrics,
                 DEEPTOOLS.out.corr,


### PR DESCRIPTION
## Changes

- Reorganize the output directory structure using the `publishDir` directive.
- Note: nextflow is in the process of transitioning away from `publishDir` towards a new `output` directive instead. We should make the switch when biowulf makes nextflow v25 the default module. See [`output-reorg_nxf-25`](https://github.com/CCBR/CHAMPAGNE/tree/output-reorg_nxf-25) for an in-progress implementation.

## Issues

fixes #223

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- [ ] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
