### PR TITLE
feat: easily override the blacklist with a custom bed or fasta file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHAMPAGNE development version
 
 - Minor documentation improvements. (#273, @kelly-sovacool)
+- Set `--blacklist` to a custom bed or fasta file to override the default blacklist used by a built-in `--genome`. (#277, @kelly-sovacool)
 
 ## CHAMPAGNE 0.5.0
 

--- a/conf/genomes.config
+++ b/conf/genomes.config
@@ -14,6 +14,20 @@ params {
             bioc_txdb = 'TxDb.Hsapiens.UCSC.hg38.knownGene'
             bioc_annot = 'org.Hs.eg.db'
         }
+        'hg19' {
+            species = "Homo sapiens"
+            fasta = "${params.index_dir}/hg19_basic/hg19.fa"
+            genes_gtf = "${params.index_dir}/hg19_basic/genes.gtf"
+            blacklist_index = "${params.index_dir}/hg19_basic/indexes/hg19.blacklist.*"
+            reference_index = "${params.index_dir/hg19_basic/bwa_index/hg19.*}"
+            chromosomes_dir = "${params.index_dir}/hg19_basic/Chromosomes"
+            chrom_sizes = "${params.index_dir}/hg19_basic/Chromosomes/chrom.sizes"
+            gene_info = "${params.index_dir}/hg19_basic/geneinfo.bed"
+            effective_genome_size = 2700000000
+            meme_motifs = "${projectDir}/assets/HOCOMOCOv11_core_HUMAN_mono_meme_format.tar.gz"
+            bioc_txdb = 'TxDb.Hsapiens.UCSC.hg38.knownGene'
+            bioc_annot = 'org.Hs.eg.db'
+        }
         'mm10' {
             species = "Mus musculus"
             fasta = "${params.index_dir}/mm10_basic/mm10_basic.fa"

--- a/conf/genomes.config
+++ b/conf/genomes.config
@@ -19,7 +19,7 @@ params {
             fasta = "${params.index_dir}/hg19_basic/hg19.fa"
             genes_gtf = "${params.index_dir}/hg19_basic/genes.gtf"
             blacklist_index = "${params.index_dir}/hg19_basic/indexes/hg19.blacklist.*"
-            reference_index = "${params.index_dir/hg19_basic/bwa_index/hg19.*}"
+            reference_index = "${params.index_dir}/hg19_basic/bwa_index/hg19.*"
             chromosomes_dir = "${params.index_dir}/hg19_basic/Chromosomes"
             chrom_sizes = "${params.index_dir}/hg19_basic/Chromosomes/chrom.sizes"
             gene_info = "${params.index_dir}/hg19_basic/geneinfo.bed"

--- a/docs/_genomes_tail.md
+++ b/docs/_genomes_tail.md
@@ -1,3 +1,18 @@
+### Custom blacklist
+
+If you'd like to override the default blacklist used by one of the built-in genomes,
+you can provide a custom blacklist bed file or fasta file:
+
+```sh
+champagne run --output /data/$USER/champagne_project \
+    --mode slurm \
+    --genome hg38 \
+    --blacklist /path/to/blacklist.bed
+```
+
+If you're providing a custom blacklist bed file, make sure its regions refer to
+the genome version you're using.
+
 ### Custom reference genome
 
 If you'd like to use a genome not available on Biowulf,
@@ -12,7 +27,7 @@ Prepare your custom reference genome with:
 
 ```sh
 champagne run --output /data/$USER/champagne_project \
-    --mode slurm -profile biowulf \
+    --mode slurm \
     -entry MAKE_REFERENCE \
     --genome custom_genome \
     --genome_fasta genome.fasta \

--- a/docs/guide/genomes.md
+++ b/docs/guide/genomes.md
@@ -28,6 +28,21 @@ These genomes can be passed to the `--genome` parameter.
 - bioc_txdb: `TxDb.Hsapiens.UCSC.hg38.knownGene`
 - bioc_annot: `org.Hs.eg.db`
 
+#### `hg19`
+
+- species: `Homo sapiens`
+- fasta: `${params.index_dir}/hg19_basic/hg19.fa`
+- genes_gtf: `${params.index_dir}/hg19_basic/genes.gtf`
+- blacklist_index: `${params.index_dir}/hg19_basic/indexes/hg19.blacklist.*`
+- reference_index: `${params.index_dir}/hg19_basic/bwa_index/hg19.*`
+- chromosomes_dir: `${params.index_dir}/hg19_basic/Chromosomes`
+- chrom_sizes: `${params.index_dir}/hg19_basic/Chromosomes/chrom.sizes`
+- gene_info: `${params.index_dir}/hg19_basic/geneinfo.bed`
+- effective_genome_size: `2700000000`
+- meme_motifs: `${projectDir}/assets/HOCOMOCOv11_core_HUMAN_mono_meme_format.tar.gz`
+- bioc_txdb: `TxDb.Hsapiens.UCSC.hg38.knownGene`
+- bioc_annot: `org.Hs.eg.db`
+
 #### `mm10`
 
 - species: `Mus musculus`
@@ -62,6 +77,21 @@ These genomes can be passed to the `--spike_genome` parameter.
 - reference_index: `${params.index_dir}/ecoli_k12/indexes/ecoli_k12.*`
 - blacklist_bed: `NO_FILE`
 
+### Custom blacklist
+
+If you'd like to override the default blacklist used by one of the built-in genomes,
+you can provide a custom blacklist bed file or fasta file:
+
+```sh
+champagne run --output /data/$USER/champagne_project \
+    --mode slurm \
+    --genome hg38 \
+    --blacklist /path/to/blacklist.bed
+```
+
+If you're providing a custom blacklist bed file, make sure its regions refer to
+the genome version you're using.
+
 ### Custom reference genome
 
 If you'd like to use a genome not available on Biowulf,
@@ -76,7 +106,7 @@ Prepare your custom reference genome with:
 
 ```sh
 champagne run --output /data/$USER/champagne_project \
-    --mode slurm -profile biowulf \
+    --mode slurm \
     -entry MAKE_REFERENCE \
     --genome custom_genome \
     --genome_fasta genome.fasta \

--- a/docs/guide/params.md
+++ b/docs/guide/params.md
@@ -60,13 +60,13 @@ The most commonly used pipeline options
 
 Use these to build a custom reference genome not already listed in conf/genomes.config. For an example, see conf/test.config.
 
-| Parameter        | Description                                                                                     | Type      | Default | Required | Hidden |
-| ---------------- | ----------------------------------------------------------------------------------------------- | --------- | ------- | -------- | ------ |
-| `genome_fasta`   | Genome fasta file                                                                               | `string`  |         |          |        |
-| `genes_gtf`      | Genome gtf file                                                                                 | `string`  |         |          |        |
-| `blacklist`      | Blacklisted sequences fasta file                                                                | `string`  |         |          |        |
-| `read_length`    | Read length used for counting unique kmers and computing the effective genome size.             | `integer` |         |          |        |
-| `rename_contigs` | File with map to translate chromosome names (see assets/R64-1-1_ensembl2UCSC.txt as an example) | `string`  |         |          |        |
+| Parameter        | Description                                                                                                                                        | Type      | Default | Required | Hidden |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- | -------- | ------ |
+| `genome_fasta`   | Genome fasta file                                                                                                                                  | `string`  |         |          |        |
+| `genes_gtf`      | Genome gtf file                                                                                                                                    | `string`  |         |          |        |
+| `blacklist`      | Custom blacklisted sequences as a fasta file or bed file. These will be filtered out of the trimmed reads before aligning to the reference genome. | `string`  |         |          |        |
+| `read_length`    | Read length used for counting unique kmers and computing the effective genome size.                                                                | `integer` |         |          |        |
+| `rename_contigs` | File with map to translate chromosome names (see assets/R64-1-1_ensembl2UCSC.txt as an example)                                                    | `string`  |         |          |        |
 
 ## General parameters
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,7 @@ params {
     // custom genome options
     genome_fasta = null
     genes_gtf   = null
-    blacklist = null
+    blacklist = null // bed or fasta
     rename_contigs = null
     read_length = null
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -70,7 +70,7 @@
                 "blacklist": {
                     "type": "string",
                     "fa_icon": "fas fa-file",
-                    "description": "Blacklisted sequences fasta file"
+                    "description": "Custom blacklisted sequences as a fasta file or bed file. These will be filtered out of the trimmed reads before aligning to the reference genome."
                 },
                 "read_length": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/CCBR/CHAMPAGNE//nextflow_schema.json",
+    "$id": "https://raw.githubusercontent.com/CCBR/CHAMPAGNE/main/nextflow_schema.json",
     "title": "CCBR/CHAMPAGNE pipeline parameters",
     "description": "CHromAtin iMmuno PrecipitAtion sequencinG aNalysis pipEline",
     "type": "object",
@@ -410,6 +410,7 @@
         {
             "$ref": "#/$defs/run_control"
         },
+        { "$ref": "#/$defs/platform_options" },
         {
             "$ref": "#/$defs/containers"
         }

--- a/subworkflows/local/prepare_blacklist.nf
+++ b/subworkflows/local/prepare_blacklist.nf
@@ -1,0 +1,30 @@
+
+include { BEDTOOLS_GETFASTA          } from '../../modules/nf-core/bedtools/getfasta/main'
+include { BWA_INDEX as BWA_INDEX_BL } from "../../modules/CCBR/bwa/index"
+
+workflow PREPARE_BLACKLIST {
+    take:
+        blacklist_file // bed or fasta
+        genome_fasta
+        rename_contigs // optional
+    main:
+
+        // blacklist bed to fasta
+        if (blacklist_file.endsWith('.bed')) {
+            BEDTOOLS_GETFASTA(blacklist_file, genome_fasta)
+            ch_blacklist_input = BEDTOOLS_GETFASTA.out.fasta
+        } else {
+            ch_blacklist_input = Channel.fromPath(blacklist_file)
+        }
+        if (rename_contigs) {
+            contig_map = file(rename_contigs, checkIfExists: true)
+            ch_blacklist_fasta = RENAME_FASTA_CONTIGS_BL(ch_blacklist_input, contig_map).fasta
+        } else {
+            ch_blacklist_fasta = ch_blacklist_input
+        }
+
+        blacklist_meta = ch_blacklist_fasta.map{ it -> [it.baseName, it]}
+        ch_blacklist_index =  BWA_INDEX_BL(blacklist_meta).index.collect()
+    emit:
+        index = ch_blacklist_index
+}


### PR DESCRIPTION
## Changes

You can now set the `--blacklist` parameter while using a built-in `--genome` to override the genome's blacklist file.

## Issues

resolves #277 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
