### PR TITLE
Fix spike-in norm: group by antibody and do not scale inputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        # https://github.com/codespell-project/codespell/issues/1498
+        args: ["--ignore-words-list=bais"]
   # Python formatting
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Minor documentation improvements. (#273, @kelly-sovacool)
 - Set `--blacklist` to a custom bed or fasta file to override the default blacklist used by a built-in `--genome`. (#277, @kelly-sovacool)
+- Fix spike-in normalization: (#279, @kelly-sovacool)
+    - Do not include inputs in the scale factor calculation.
+    - Group samples by antibody for scale factor calculation.
+    - Create separate parameters for controlling the deeptools normalization method for samples and inputs.
 
 ## CHAMPAGNE 0.5.0
 

--- a/bin/make_sf_table.py
+++ b/bin/make_sf_table.py
@@ -6,18 +6,19 @@ Usage:
     python make_sf_table.py scaling_factors.tsv <ids> <counts> [<outfilename>]
 
 Example:
-    python make_sf_table.py "id1,id2,id3" "100,200,300" spike_sf.tsv
+    python make_sf_table.py scaling_factors_1.tsv,scaling_factors_2.tsv id1,id2,id3 100,200,300 spike_sf.tsv
 """
 import sys
 
 
-def main(infilename, ids, counts, outfilename="spike_sf.tsv"):
+def main(infilenames, ids, counts, outfilename="spike_sf.tsv"):
     data = dict()
-    with open(infilename, "r") as infile:
-        header = next(infile)
-        for line in infile:
-            sample, scaling_factor = line.strip().split("\t")
-            data[sample] = [scaling_factor]
+    for infilename in infilenames.split(","):
+        with open(infilename, "r") as infile:
+            header = next(infile)
+            for line in infile:
+                sample, scaling_factor = line.strip().split("\t")
+                data[sample] = [scaling_factor]
 
     for sample, count in zip(ids.split(","), counts.split(",")):
         data[sample].append(count)

--- a/conf/genomes.config
+++ b/conf/genomes.config
@@ -18,7 +18,7 @@ params {
             species = "Homo sapiens"
             fasta = "${params.index_dir}/hg19_basic/hg19.fa"
             genes_gtf = "${params.index_dir}/hg19_basic/genes.gtf"
-            blacklist_index = "${params.index_dir}/hg19_basic/indexes/hg19.blacklist.*"
+            blacklist_index = "${params.index_dir}/hg19_basic/indexes/blacklist/hg19.blacklist.*"
             reference_index = "${params.index_dir}/hg19_basic/bwa_index/hg19.*"
             chromosomes_dir = "${params.index_dir}/hg19_basic/Chromosomes"
             chrom_sizes = "${params.index_dir}/hg19_basic/Chromosomes/chrom.sizes"

--- a/conf/test_spikein.config
+++ b/conf/test_spikein.config
@@ -8,5 +8,5 @@ params {
     sicer_species = 'hg38'
 
     spike_genome = 'dmelr6.32'
-    deeptools_normalize_using = "None" // recommend no additional normalization for spike-in
+    deeptools_normalize_samples = "None" // recommend no additional normalization for spike-in
 }

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -87,7 +87,7 @@ each sample.
 `bigwigs/` contains the bigwig files for each sample; one before removing input
 reads (`{id}.bw`) and one with input reads removed (`{id}.inputnorm.bw`).
 
-These are normalized with the method set by the `deeptools_normalize_using` parameter.
+These are normalized with the method set by the `deeptools_normalize_samples` parameter.
 
 If using a spike-in genome, these are normalized according the spike-in
 parameters set. See the [Spike-in normalization doc](spike-in.md) for more

--- a/docs/guide/spike-in.md
+++ b/docs/guide/spike-in.md
@@ -5,6 +5,9 @@ The data are normalized based on the number of reads aligning to the spike-in
 genome to account for differences in sequencing depth or other technical
 variations between samples.
 
+Samples are grouped by antibody when calculating the scaling factors.
+Inputs are excluded from this calculation.
+
 ### Spike-in options
 
 You must set the `spike_genome` parameter to the name of a [supported genome](genomes.md#spike-in-genomes)

--- a/docs/guide/spike-in.md
+++ b/docs/guide/spike-in.md
@@ -11,9 +11,11 @@ You must set the `spike_genome` parameter to the name of a [supported genome](ge
 (e.g. `dmelr6.32`, `ecoli_k12`) that is different from the `genome` used for the
 main analysis.
 When using spike-in normalizations, we recommend setting
-`deeptools_normalize_using` to `None` so that additional normalization isn't
+`deeptools_normalize_samples` to `None` so that additional normalization isn't
 performed (see [this
 discussion](https://www.github.com/deeptools/deepTools/issues/1073#issuecomment-859326520)).
+You can separately set the normalization method for input samples with the
+`deeptools_normalize_input` parameter.
 
 View the [spike-in options](params.md#spike-in-options) for a full list of
 parameters that can be set for spike-in normalization.
@@ -44,7 +46,7 @@ champagne run \
     --genome hg38 \
     --input assets/samplesheet_full_spikein.csv \
     --spike_genome ecoli_k12 \
-    --deeptools_normalize_using None \
+    --deeptools_normalize_samples None \
     --spike_norm_method delorenzi
 ```
 
@@ -56,6 +58,6 @@ champagne run \
     --genome hg38 \
     --input assets/samplesheet_full_spikein.csv \
     --spike_genome dmelr6.32 \
-    --deeptools_normalize_using None \
+    --deeptools_normalize_samples None \
     --spike_norm_method guenther
 ```

--- a/main.nf
+++ b/main.nf
@@ -103,9 +103,6 @@ workflow {
     sample_sheet = Channel.fromPath(file(params.input, checkIfExists: true))
     contrast_sheet = params.contrasts ? Channel.fromPath(file(params.contrasts, checkIfExists: true)) : params.contrasts
     raw_fastqs = INPUT_CHECK(sample_sheet, contrast_sheet).reads
-    raw_fastqs
-        | map{ meta, fq -> meta.input ? [ meta, fq ] : null }
-        | view
 
     CUTADAPT(raw_fastqs).reads | POOL_INPUTS
     trimmed_fastqs = POOL_INPUTS.out.reads

--- a/modules/local/deeptools.nf
+++ b/modules/local/deeptools.nf
@@ -43,7 +43,7 @@ process BAM_COVERAGE {
     container "${params.containers_deeptools}"
 
     input:
-        tuple val(meta), path(bam), path(bai), val(scaling_factor), val(fraglen), val(effective_genome_size)
+        tuple val(meta), path(bam), path(bai), val(norm_method), val(scaling_factor), val(fraglen), val(effective_genome_size)
 
     output:
         tuple val(meta), path("${meta.id}.bw"), emit: bigwig
@@ -58,7 +58,7 @@ process BAM_COVERAGE {
       --binSize ${params.deeptools_bin_size} \\
       --smoothLength ${params.deeptools_smooth_length} \\
       --ignoreForNormalization ${params.deeptools_excluded_chroms} \\
-      --normalizeUsing ${params.deeptools_normalize_using} \\
+      --normalizeUsing ${norm_method} \\
       --effectiveGenomeSize ${effective_genome_size} \\
       --scaleFactor ${scaling_factor} \\
       ${args}

--- a/modules/local/deeptools.nf
+++ b/modules/local/deeptools.nf
@@ -3,7 +3,7 @@ process MULTIBAM_SUMMARY {
 
     container "${params.containers_deeptools}"
 
-    input: // TODO add fraglen
+    input:
       tuple val(metas), path(bams), path(bais), val(fraglen), path(blacklist_bed)
 
     output:
@@ -11,7 +11,7 @@ process MULTIBAM_SUMMARY {
       path("*scalingFactors.tsv"), emit: sf
 
     script:
-    def prefix = task.ext.prefix ?: "multiBam"
+    def prefix = task.ext.prefix ?: "multiBam_${metas[0].antibody}"
     def args = metas[0].single_end ? "--extendReads ${fraglen}" : ''
     if (blacklist_bed.exists()) {
       args = "${args} --blackListFileName ${blacklist_bed}"
@@ -28,7 +28,7 @@ process MULTIBAM_SUMMARY {
                   --minMappingQuality ${params.spike_deeptools_min_map_quality} \\
                   --ignoreDuplicates \\
                   ${args} \\
-                  -o multiBamSummary.npz \\
+                  -o ${prefix}_Summary.npz \\
                   --outRawCounts ${prefix}_counts.tsv \\
                   --scalingFactors ${prefix}_scalingFactors.tsv
     """

--- a/modules/local/spikein/compute_scalingFactor/main.nf
+++ b/modules/local/spikein/compute_scalingFactor/main.nf
@@ -9,7 +9,7 @@ process COMPUTE_SCALINGFACTOR {
         tuple val(metas), val(counts)
 
     output:
-        path("scaling_factors.tsv")
+        path("*scaling-factors.tsv")
 
     when:
         task.ext.when == null || task.ext.when
@@ -17,7 +17,8 @@ process COMPUTE_SCALINGFACTOR {
     script:
     ids = metas.collect{ it.id }.join(',')
     counts_joined = counts.join(',')
+    outfile = "${metas[0].antibody}_scaling-factors.tsv"
     """
-    compute_scaling_factors.py ${ids} ${counts_joined}
+    compute_scaling_factors.py ${ids} ${counts_joined} ${outfile}
     """
 }

--- a/modules/local/spikein/make_table/main.nf
+++ b/modules/local/spikein/make_table/main.nf
@@ -20,6 +20,6 @@ process MAKE_TABLE {
     ids = metas.collect{ it.id }.join(',')
     counts_joined = spikein_counts.join(',')
     """
-    make_sf_table.py ${sf_tsv} ${ids} ${counts_joined}
+    make_sf_table.py ${sf_tsvs} ${ids} ${counts_joined}
     """
 }

--- a/modules/local/spikein/make_table/main.nf
+++ b/modules/local/spikein/make_table/main.nf
@@ -16,6 +16,7 @@ process MAKE_TABLE {
         task.ext.when == null || task.ext.when
 
     script:
+    sf_tsvs = sf_tsv.join(',')
     ids = metas.collect{ it.id }.join(',')
     counts_joined = spikein_counts.join(',')
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,6 +41,8 @@ params {
     deeptools_bin_size = 25
     deeptools_smooth_length = 75
     deeptools_normalize_using = "RPGC" // set this to "None" if using a spike-in control
+    deeptools_normalize_samples = deeptools_normalize_using
+    deeptools_normalize_input = "RPGC" // this is separate from the above, only for input samples
     deeptools_excluded_chroms = "chrM chrX chrY"
 
     multiqc_config = "${projectDir}/assets/multiqc_config.yaml"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "The most commonly used pipeline options",
-            "required": ["input", "genome"],
+            "required": [
+                "input",
+                "genome"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -46,7 +49,14 @@
                 "publish_dir_mode": {
                     "type": "string",
                     "default": "link",
-                    "enum": ["link", "copy", "move", "copyNoFollow", "rellink", "symlink"],
+                    "enum": [
+                        "link",
+                        "copy",
+                        "move",
+                        "copyNoFollow",
+                        "rellink",
+                        "symlink"
+                    ],
                     "description": "How to publish files to the results directory. This parameter sets Nextflow's workflow.output.mode configuration option."
                 }
             }
@@ -124,7 +134,10 @@
                 "spike_norm_method": {
                     "type": "string",
                     "default": "delorenzi",
-                    "enum": ["delorenzi", "guenther"],
+                    "enum": [
+                        "delorenzi",
+                        "guenther"
+                    ],
                     "description": "Method to compute scaling factors for spike-in normalization. \"guenther\" uses a simple fraction of the reads aligning to the spike-in genome as described in <https://doi.org/10.1016/j.celrep.2014.10.018>. \"delorenzi\" uses deepTools multiBamSummary with --scalingFactors, which is similar to the method described in <https://doi.org/10.1101/gr.168260.113>."
                 },
                 "spike_deeptools_bin_size": {
@@ -145,6 +158,22 @@
             "description": "",
             "default": "",
             "properties": {
+                "deeptools_normalize_using": {
+                    "type": "string",
+                    "default": "RPGC",
+                    "description": "This parameter has been renamed to \"deeptools_normalize_samples\". It is kept for backward compatibility.",
+                    "hidden": true
+                },
+                "deeptools_normalize_samples": {
+                    "type": "string",
+                    "default": "RPGC",
+                    "description": "This normalization method is applied to the samples only, not the inputs. If using a spike-in genome, recommend setting this to \"None\""
+                },
+                "deeptools_normalize_input": {
+                    "type": "string",
+                    "default": "RPGC",
+                    "description": "Normalization method applied to inputs only. This way you can disable additional normalization for samples such as when using spike-in normalization, but still normalize the inputs."
+                },
                 "deeptools_bin_size": {
                     "type": "integer",
                     "default": 25
@@ -152,11 +181,6 @@
                 "deeptools_smooth_length": {
                     "type": "integer",
                     "default": 75
-                },
-                "deeptools_normalize_using": {
-                    "type": "string",
-                    "default": "RPGC",
-                    "description": "If using a spike-in genome, recommend setting this to \"None\""
                 },
                 "deeptools_excluded_chroms": {
                     "type": "string",
@@ -410,7 +434,9 @@
         {
             "$ref": "#/$defs/run_control"
         },
-        { "$ref": "#/$defs/platform_options" },
+        {
+            "$ref": "#/$defs/platform_options"
+        },
         {
             "$ref": "#/$defs/containers"
         }

--- a/subworkflows/local/deeptools/main.nf
+++ b/subworkflows/local/deeptools/main.nf
@@ -20,9 +20,12 @@ workflow DEEPTOOLS {
     main:
 
         deduped_bam
-            | map{ meta, bam, bai -> [ meta.id, meta, bam, bai] }
+            | map{ meta, bam, bai ->
+                def norm_method = meta.is_input ? params.deeptools_normalize_input : params.deeptools_normalize_samples
+                [ meta.id, meta, bam, bai, norm_method ]
+            }
             | join(scaling_factors)
-            | map{ id, meta, bam, bai, sf -> [meta, bam, bai, sf] }
+            | map{ id, meta, bam, bai, norm_method, sf -> [meta, bam, bai, norm_method, sf] }
             | join(frag_lengths)
             | combine(effective_genome_size)
             | BAM_COVERAGE

--- a/subworkflows/local/prepare_blacklist.nf
+++ b/subworkflows/local/prepare_blacklist.nf
@@ -11,11 +11,13 @@ workflow PREPARE_BLACKLIST {
     main:
 
         // blacklist bed to fasta
-        if (blacklist_file.endsWith('.bed')) {
+        if (blacklist_file.extension == 'bed') {
             BEDTOOLS_GETFASTA(blacklist_file, genome_fasta)
             ch_blacklist_input = BEDTOOLS_GETFASTA.out.fasta
-        } else {
+        } else if (blacklist_file.extension == 'fasta' || blacklist_file.extension == 'fa') {
             ch_blacklist_input = Channel.fromPath(blacklist_file)
+        } else {
+            error "Unsupported blacklist file format extension: ${blacklist_file.extension}. Expected .bed or .fasta/.fa"
         }
         if (rename_contigs) {
             contig_map = file(rename_contigs, checkIfExists: true)

--- a/subworkflows/local/prepare_blacklist.nf
+++ b/subworkflows/local/prepare_blacklist.nf
@@ -1,6 +1,7 @@
 
 include { BEDTOOLS_GETFASTA          } from '../../modules/nf-core/bedtools/getfasta/main'
 include { BWA_INDEX as BWA_INDEX_BL } from "../../modules/CCBR/bwa/index"
+include { RENAME_FASTA_CONTIGS as RENAME_FASTA_CONTIGS_BL } from "../../modules/local/prepare_genome.nf"
 
 workflow PREPARE_BLACKLIST {
     take:

--- a/subworkflows/local/spikein/main.nf
+++ b/subworkflows/local/spikein/main.nf
@@ -46,8 +46,7 @@ workflow ALIGN_SPIKEIN {
         } else {
             error "Unknown spike-in normalization method: ${params.spike_norm_method}"
         }
-
-        MAKE_TABLE( ch_sf_tsv, ch_spike_counts )
+        MAKE_TABLE( ch_sf_tsv.collect(), ch_spike_counts.collect() )
         ch_sf_tsv
             | splitCsv(header: true, sep: '\t')
             | map{ row -> [ row.sample, row.scalingFactor ] }

--- a/subworkflows/local/spikein/main.nf
+++ b/subworkflows/local/spikein/main.nf
@@ -20,9 +20,9 @@ workflow ALIGN_SPIKEIN {
         BWA_MEM( ch_fastq, ch_spikein_index )
         SAMTOOLS_COUNT( BWA_MEM.out.bam )
         SAMTOOLS_COUNT.out.count
-            | map{ meta, count -> [1, meta, count]}
+            | map{ meta, count -> [meta.antibody, meta, count]}
             | groupTuple()
-            | map{ idx, metas, counts -> [ metas, counts ] }
+            | map{ ab, metas, counts -> [ metas, counts ] }
             | set{ ch_spike_counts }
 
         if (params.spike_norm_method == 'guenther') {
@@ -35,9 +35,9 @@ workflow ALIGN_SPIKEIN {
                 | min()
                 | set{ min_fraglen }
             BWA_MEM.out.bam
-                | map{ meta, bam, bai -> [1, meta, bam, bai]}
+                | map{ meta, bam, bai -> [meta.antibody, meta, bam, bai]}
                 | groupTuple()
-                | map{ idx, metas, bams, bais -> [ metas, bams, bais ] }
+                | map{ ab, metas, bams, bais -> [ metas, bams, bais ] }
                 | combine(min_fraglen)
                 | combine(ch_spikein_blacklist_bed)
                 | MULTIBAM_SUMMARY


### PR DESCRIPTION
## Changes

- Do not include inputs for spike-in scale factor calculation.
- Group samples by antibody when calculating scale factors.
- Create separate deeptools normalization method paramters for samples & inputs.

## Issues

fixes #275 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
