### PR TITLE
fix: skip fastq screen if conf not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## CHAMPAGNE development version
 
+- Skip fastq screen if the config file or database are not provided. (#351, @kelly-sovacool)
+
 ## CHAMPAGNE 0.6.0
 
 - Support uncompressed fastq files -- they will be gzipped after the samplesheet check. (#306, @kelly-sovacool)

--- a/subworkflows/local/qc.nf
+++ b/subworkflows/local/qc.nf
@@ -25,11 +25,15 @@ workflow QC {
         raw_fastqs.combine(Channel.value("raw")) | FASTQC_RAW
         trimmed_fastqs.combine(Channel.value("trimmed")) | FASTQC_TRIMMED
         ch_multiqc = Channel.empty()
-        trimmed_fastqs
-            .combine(Channel.fromPath(params.fastq_screen_conf, checkIfExists: true))
-            .combine(Channel.fromPath(params.fastq_screen_db_dir,
-                                        type: 'dir', checkIfExists: true)) | FASTQ_SCREEN
-        ch_multiqc = ch_multiqc.mix(FASTQ_SCREEN.out.screen)
+        if (params.fastq_screen_conf && params.fastq_screen_db_dir) {
+            trimmed_fastqs
+                .combine(Channel.fromPath(params.fastq_screen_conf, checkIfExists: true))
+                .combine(Channel.fromPath(params.fastq_screen_db_dir,
+                                            type: 'dir', checkIfExists: true)) | FASTQ_SCREEN
+            ch_multiqc = ch_multiqc.mix(FASTQ_SCREEN.out.screen)
+        } else {
+            log.info("Skipping FASTQ_SCREEN: fastq_screen_conf and/or fastq_screen_db_dir are null")
+        }
 
         PRESEQ(aligned_filtered_bam)
         // when preseq fails, write NAs for the stats that are calculated from its log


### PR DESCRIPTION
## Changes

most users will want to use fastq screen, but if the conf/db is not available, skip it

## Issues

towards #346

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
