### PR TITLE
fix: make docker container spec compatible with docker engine

### DIFF
--- a/modules/CCBR/samtools/flagstat/main.nf
+++ b/modules/CCBR/samtools/flagstat/main.nf
@@ -5,7 +5,7 @@ process SAMTOOLS_FLAGSTAT {
     conda "bioconda::samtools=1.17"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'quay.io/biocontainers/samtools:1.17--h00cdaf9_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/local/consensus/corces/main.nf
+++ b/modules/local/consensus/corces/main.nf
@@ -1,7 +1,7 @@
 process CONSENSUS_CORCES {
 
     tag "${meta.id}.${meta.tool}"
-    container 'docker://nciccbr/ccbr_atacseq:v11-feat'
+    container 'nciccbr/ccbr_atacseq:v11-feat'
 
     input:
         tuple val(meta), path(peaks), path(chrom_sizes)

--- a/modules/local/qc.nf
+++ b/modules/local/qc.nf
@@ -5,7 +5,7 @@ process FASTQC {
     label 'process_high'
 
     //container "${params.containers_fastqc}"
-    container 'docker://nciccbr/ccrgb_qctools:v4.0'
+    container 'nciccbr/ccrgb_qctools:v4.0'
 
     input:
         tuple val(meta), path(fastq), val(fqtype)

--- a/modules/nf-core/bedtools/getfasta/main.nf
+++ b/modules/nf-core/bedtools/getfasta/main.nf
@@ -5,7 +5,7 @@ process BEDTOOLS_GETFASTA {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0' :
-        'biocontainers/bedtools:2.30.0--hc088bd4_0' }"
+        'quay.io/biocontainers/bedtools:2.30.0--hc088bd4_0' }"
 
     input:
     path bed

--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -5,7 +5,7 @@ process CAT_CAT {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/pigz:2.3.4' :
-        'biocontainers/pigz:2.3.4' }"
+        'quay.io/biocontainers/pigz:2.3.4' }"
 
     input:
     tuple val(meta), path(files_in)

--- a/modules/nf-core/custom/sratoolsncbisettings/main.nf
+++ b/modules/nf-core/custom/sratoolsncbisettings/main.nf
@@ -5,7 +5,7 @@ process CUSTOM_SRATOOLSNCBISETTINGS {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
-        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
+        'quay.io/biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     output:
     path('*.mkfg')     , emit: ncbi_settings

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -5,7 +5,7 @@ process SRATOOLS_FASTERQDUMP {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
-        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
+        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -5,7 +5,7 @@ process SRATOOLS_PREFETCH {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
-        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
+        'quay.io/biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     input:
     tuple val(meta), val(id)


### PR DESCRIPTION
## Changes

- `docker://` prefix works with singularity, but is not necessary and breaks for docker (https://docs.seqera.io/nextflow/reference/config#singularity)
- `quay.io` prefix may be required for biocontainers

## Issues

fixes #351

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
